### PR TITLE
Allow different metric-to-weight-functions

### DIFF
--- a/isumap.py
+++ b/isumap.py
@@ -331,7 +331,7 @@ def isumap(data,
     :param sgd_saveloss:  bool - whether to save plots of SGD loss
     :param tconorm: the t-conorm used for symmetrization - one of ['canonical', 'probabilistic sum', 'bounded sum', 'drastic sum', 'Einstein sum', 'nilpotent maximum']
     :param phi: None or str or callable: phi function to transfer metrics to fuzzy weights. If None, defaults to exponential function.
-    If a string, must be one of IMPLEMENTED_PHIS. Else, custom function may be used. Has to be callable, and an inverse phi_inv has to be provided.
+    If a string, must be one of ['exp','half_normal','log_normal','pareto','uniform']. Else, custom function may be used. Has to be callable, and an inverse phi_inv has to be provided.
     Does not do anything if t-conorm is 'canonical'.
     :param phi_inv: None or callable: inverse of phi function. If None, defaults to log. Else, must be callable inveres of phi.
     :param **phi_params**: additional parameters to pass to the phi function.

--- a/minimal_example_phi.py
+++ b/minimal_example_phi.py
@@ -1,0 +1,38 @@
+
+from time import time
+from isumap import isumap
+from data_and_plots import plot_data, createMammoth, load_MNIST, printtime, createNonUniformHemisphere, createSwissRole, createFourGaussians, createMoons, createTorus, load_FashionMNIST
+from multiprocessing import cpu_count
+
+k = 15
+d = 2
+N = 1000
+normalize = True
+metricMDS = True
+distBeyondNN = True
+tconorm = "probabilistic sum"
+
+if __name__ == '__main__':
+    data, labels = createNonUniformHemisphere(N)
+    
+    
+    plot_data(data,labels,title="Initial dataset",display=True)
+    
+
+    for phi in ['exp','half_normal','log_normal','pareto','uniform']:
+        t0 = time()
+
+        finalEmbedding, clusterLabels = isumap(data, k, d,
+            normalize = normalize, distBeyondNN=distBeyondNN, verbose=False, dataIsDistMatrix=False, dataIsGeodesicDistMatrix = False, saveDistMatrix = False, labels=labels, initialization="cMDS", metricMDS=metricMDS, 
+                                               sgd_n_epochs = 1500, sgd_lr=1e-2, sgd_batch_size = None,
+                                               sgd_max_epochs_no_improvement = 75, sgd_loss = 'MSE', 
+                                               sgd_saveplots_of_initializations=True, sgd_saveloss=True,
+                                               tconorm = tconorm,phi=phi)
+        t1 = time()
+        
+        title = "Non-uniform Hemisphere N_" + str(N) + " k_" + str(k) + " beyondNN_" + str(distBeyondNN) + " normalize_" + str(normalize) + " metricMDS_" + str(metricMDS) + " tconorm_" + tconorm + "phi_" + phi
+        plot_data(finalEmbedding,labels,title=title,display=True)
+        print("\nResult saved in './Results/" + title + ".png'")
+        
+        printtime("Isumap total time",t1-t0)
+    


### PR DESCRIPTION
Included possibility to choose different phi function to transform metrics to weights.
When using conorms different than the canonical one, user can choose different function phi as a parameter in the isumap function (either choosing a string for using predefined ones, or using a custom function). Note that for canonical t-conorm, this does not make any difference.